### PR TITLE
ZPL label work for Urine, serum, IFE, and formalin added labels

### DIFF
--- a/YellowstonePathology/Business/Label.Model/FormalinAddedZPLLabel.cs
+++ b/YellowstonePathology/Business/Label.Model/FormalinAddedZPLLabel.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace YellowstonePathology.Business.Label.Model
 {
-    public class SerumZPLLabel
+    public class FormalinAddedZPLLabel
     {
-        public SerumZPLLabel()
+        public FormalinAddedZPLLabel()
         {
 
         }
@@ -37,10 +37,8 @@ namespace YellowstonePathology.Business.Label.Model
             string line3 = containerId.Substring(28);
 
 
-            result.Append("^FO" + (xOffset + 65) + ",030^ATN,50^FD" + "Serum" + "^FS");
-            result.Append("^FO" + (xOffset + 30) + ",090^ATN,50^FD" + "84165-26" + "^FS");
-            result.Append("^FO" + (xOffset + 170) + ",150^ATN,50^FD" + "MD" + "^FS");
-            result.Append("^FO" + (xOffset + 30) + ",210^ATN,50^FD" + "    /    /17" + "^FS");
+            result.Append("^FO" + (xOffset + 10) + ",030^ATN,50^FD" + "Formalin" + "^FS");
+            result.Append("^FO" + (xOffset + 10) + ",080^ATN,50^FD" + "Added" + "^FS");
         }
     }
 }

--- a/YellowstonePathology/Business/Label.Model/IFEZPLLabel.cs
+++ b/YellowstonePathology/Business/Label.Model/IFEZPLLabel.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace YellowstonePathology.Business.Label.Model
 {
-    public class SerumZPLLabel
+    public class IFEZPLLabel
     {
-        public SerumZPLLabel()
+        public IFEZPLLabel()
         {
 
         }
@@ -37,8 +37,9 @@ namespace YellowstonePathology.Business.Label.Model
             string line3 = containerId.Substring(28);
 
 
-            result.Append("^FO" + (xOffset + 65) + ",030^ATN,50^FD" + "Serum" + "^FS");
-            result.Append("^FO" + (xOffset + 30) + ",090^ATN,50^FD" + "84165-26" + "^FS");
+            result.Append("^FO" + (xOffset + 65) + ",030^ATN,50^FD" + "IFE" + "^FS");
+            result.Append("^FO" + (xOffset + 30) + ",070^ARN,50^FD" + "86334-26 x1" + "^FS");
+            result.Append("^FO" + (xOffset + 30) + ",100^ARN,50^FD" + "82784-26 x3" + "^FS");
             result.Append("^FO" + (xOffset + 170) + ",150^ATN,50^FD" + "MD" + "^FS");
             result.Append("^FO" + (xOffset + 30) + ",210^ATN,50^FD" + "    /    /17" + "^FS");
         }

--- a/YellowstonePathology/Business/Label.Model/UrineZPLLabel.cs
+++ b/YellowstonePathology/Business/Label.Model/UrineZPLLabel.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace YellowstonePathology.Business.Label.Model
 {
-    public class SerumZPLLabel
+    public class UrineZPLLabel
     {
-        public SerumZPLLabel()
+        public UrineZPLLabel()
         {
 
         }
@@ -37,8 +37,8 @@ namespace YellowstonePathology.Business.Label.Model
             string line3 = containerId.Substring(28);
 
 
-            result.Append("^FO" + (xOffset + 65) + ",030^ATN,50^FD" + "Serum" + "^FS");
-            result.Append("^FO" + (xOffset + 30) + ",090^ATN,50^FD" + "84165-26" + "^FS");
+            result.Append("^FO" + (xOffset + 65) + ",030^ATN,50^FD" + "Urine" + "^FS");
+            result.Append("^FO" + (xOffset + 30) + ",090^ATN,50^FD" + "84166-26" + "^FS");
             result.Append("^FO" + (xOffset + 170) + ",150^ATN,50^FD" + "MD" + "^FS");
             result.Append("^FO" + (xOffset + 30) + ",210^ATN,50^FD" + "    /    /17" + "^FS");
         }

--- a/YellowstonePathology/UI/AdministrationWorkspace.xaml.cs
+++ b/YellowstonePathology/UI/AdministrationWorkspace.xaml.cs
@@ -323,7 +323,7 @@ namespace YellowstonePathology.UI
         private void ButtonSerumLabels_Click(object sender, RoutedEventArgs e)
         {
             Business.Label.Model.ZPLPrinter printer = new Business.Label.Model.ZPLPrinter("10.1.1.21");
-            int pageCount = 1;
+            int pageCount = 50;
             for (int x = 0; x < pageCount; x++)
             {
                 string commands = Business.Label.Model.SerumZPLLabel.GetCommands();
@@ -334,7 +334,7 @@ namespace YellowstonePathology.UI
         private void ButtonFormalinAddedLabels_Click(object sender, RoutedEventArgs e)
         {
             Business.Label.Model.ZPLPrinter printer = new Business.Label.Model.ZPLPrinter("10.1.1.21");
-            int pageCount = 1;
+            int pageCount = 50;
             for (int x = 0; x < pageCount; x++)
             {
                 string commands = Business.Label.Model.FormalinAddedZPLLabel.GetCommands();
@@ -345,7 +345,7 @@ namespace YellowstonePathology.UI
         private void ButtonIFLabels_Click(object sender, RoutedEventArgs e)
         {
             Business.Label.Model.ZPLPrinter printer = new Business.Label.Model.ZPLPrinter("10.1.1.21");
-            int pageCount = 1;
+            int pageCount = 50;
             for (int x = 0; x < pageCount; x++)
             {
                 string commands = Business.Label.Model.IFEZPLLabel.GetCommands();
@@ -356,7 +356,7 @@ namespace YellowstonePathology.UI
         private void ButtonUrineLabels_Click(object sender, RoutedEventArgs e)
         {
             Business.Label.Model.ZPLPrinter printer = new Business.Label.Model.ZPLPrinter("10.1.1.21");
-            int pageCount = 1;
+            int pageCount = 50;
             for (int x = 0; x < pageCount; x++)
             {
                 string commands = Business.Label.Model.UrineZPLLabel.GetCommands();

--- a/YellowstonePathology/UI/AdministrationWorkspace.xaml.cs
+++ b/YellowstonePathology/UI/AdministrationWorkspace.xaml.cs
@@ -323,7 +323,7 @@ namespace YellowstonePathology.UI
         private void ButtonSerumLabels_Click(object sender, RoutedEventArgs e)
         {
             Business.Label.Model.ZPLPrinter printer = new Business.Label.Model.ZPLPrinter("10.1.1.21");
-            int pageCount = 2;
+            int pageCount = 1;
             for (int x = 0; x < pageCount; x++)
             {
                 string commands = Business.Label.Model.SerumZPLLabel.GetCommands();
@@ -333,17 +333,35 @@ namespace YellowstonePathology.UI
 
         private void ButtonFormalinAddedLabels_Click(object sender, RoutedEventArgs e)
         {
-               
+            Business.Label.Model.ZPLPrinter printer = new Business.Label.Model.ZPLPrinter("10.1.1.21");
+            int pageCount = 1;
+            for (int x = 0; x < pageCount; x++)
+            {
+                string commands = Business.Label.Model.FormalinAddedZPLLabel.GetCommands();
+                printer.Print(commands);
+            }
         }
 
         private void ButtonIFLabels_Click(object sender, RoutedEventArgs e)
         {
-            
+            Business.Label.Model.ZPLPrinter printer = new Business.Label.Model.ZPLPrinter("10.1.1.21");
+            int pageCount = 1;
+            for (int x = 0; x < pageCount; x++)
+            {
+                string commands = Business.Label.Model.IFEZPLLabel.GetCommands();
+                printer.Print(commands);
+            }
         }
 
         private void ButtonUrineLabels_Click(object sender, RoutedEventArgs e)
         {
-            
+            Business.Label.Model.ZPLPrinter printer = new Business.Label.Model.ZPLPrinter("10.1.1.21");
+            int pageCount = 1;
+            for (int x = 0; x < pageCount; x++)
+            {
+                string commands = Business.Label.Model.UrineZPLLabel.GetCommands();
+                printer.Print(commands);
+            }
         }
 
 		private void ButtonAccessionSlideOrderTracking_Click(object sender, RoutedEventArgs e)

--- a/YellowstonePathology/UserInterface.csproj
+++ b/YellowstonePathology/UserInterface.csproj
@@ -997,6 +997,9 @@
     <Compile Include="Business\Label.Model\CassettePrinter.cs" />
     <Compile Include="Business\Label.Model\ContainerPaperLabel.cs" />
     <Compile Include="Business\Label.Model\ContainerPaperLabelPrinter.cs" />
+    <Compile Include="Business\Label.Model\UrineZPLLabel.cs" />
+    <Compile Include="Business\Label.Model\IFEZPLLabel.cs" />
+    <Compile Include="Business\Label.Model\FormalinAddedZPLLabel.cs" />
     <Compile Include="Business\Label.Model\SerumZPLLabel.cs" />
     <Compile Include="Business\Label.Model\HistologySlidePaperZPLLabel.cs" />
     <Compile Include="Business\Label.Model\HistologyBlockPaperZPLLabel.cs" />


### PR DESCRIPTION
changed how the labels for:
Formalin Added,
IFE,
Urine,
Serum
Are created and printed to fix an error with printing on windows 10 that the old format had. The new format is in ZPL.